### PR TITLE
Rpk admin disaster recovery

### DIFF
--- a/src/go/rpk/pkg/api/admin/api_cloud_storage.go
+++ b/src/go/rpk/pkg/api/admin/api_cloud_storage.go
@@ -1,0 +1,37 @@
+// Copyright 2023 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package admin
+
+import (
+	"context"
+	"net/http"
+)
+
+// RecoveryRequestParams represents the request body schema for the automated recovery API endpoint.
+type RecoveryRequestParams struct {
+	TopicNamesPattern string `json:"topic_names_pattern"`
+	RetentionBytes    int    `json:"retention_bytes"`
+	RetentionMs       int    `json:"retention_ms"`
+}
+
+type RecoveryStartResponse struct {
+	Code    int    `json:"code"`
+	Message string `json:"message"`
+}
+
+// StartAutomatedRecovery starts the automated recovery process by sending a request to the automated recovery API endpoint.
+func (a *AdminAPI) StartAutomatedRecovery(ctx context.Context, topicNamesPattern string) (RecoveryStartResponse, error) {
+	requestParams := &RecoveryRequestParams{
+		TopicNamesPattern: topicNamesPattern,
+	}
+	var response RecoveryStartResponse
+
+	return response, a.sendAny(ctx, http.MethodPost, "/v1/cloud_storage/automated_recovery", requestParams, &response)
+}

--- a/src/go/rpk/pkg/api/admin/api_cloud_storage.go
+++ b/src/go/rpk/pkg/api/admin/api_cloud_storage.go
@@ -56,4 +56,3 @@ func (a *AdminAPI) PollAutomatedRecoveryStatus(ctx context.Context) (*TopicRecov
 	var response TopicRecoveryStatus
 	return &response, a.sendAny(ctx, http.MethodGet, "/v1/cloud_storage/automated_recovery", http.NoBody, &response)
 }
-

--- a/src/go/rpk/pkg/api/admin/api_cloud_storage.go
+++ b/src/go/rpk/pkg/api/admin/api_cloud_storage.go
@@ -26,6 +26,21 @@ type RecoveryStartResponse struct {
 	Message string `json:"message"`
 }
 
+// TopicDownloadCounts represents the count of downloads for a topic.
+type TopicDownloadCounts struct {
+	TopicNamespace      string `json:"topic_namespace"`
+	PendingDownloads    int    `json:"pending_downloads"`
+	SuccessfulDownloads int    `json:"successful_downloads"`
+	FailedDownloads     int    `json:"failed_downloads"`
+}
+
+// TopicRecoveryStatus represents the status of the automated recovery for a topic.
+type TopicRecoveryStatus struct {
+	State           string                `json:"state"`
+	TopicDownloads  []TopicDownloadCounts `json:"topic_download_counts"`
+	RecoveryRequest RecoveryRequestParams `json:"request"`
+}
+
 // StartAutomatedRecovery starts the automated recovery process by sending a request to the automated recovery API endpoint.
 func (a *AdminAPI) StartAutomatedRecovery(ctx context.Context, topicNamesPattern string) (RecoveryStartResponse, error) {
 	requestParams := &RecoveryRequestParams{
@@ -35,3 +50,10 @@ func (a *AdminAPI) StartAutomatedRecovery(ctx context.Context, topicNamesPattern
 
 	return response, a.sendAny(ctx, http.MethodPost, "/v1/cloud_storage/automated_recovery", requestParams, &response)
 }
+
+// PollAutomatedRecoveryStatus polls the automated recovery status API endpoint to retrieve the latest status of the recovery process.
+func (a *AdminAPI) PollAutomatedRecoveryStatus(ctx context.Context) (*TopicRecoveryStatus, error) {
+	var response TopicRecoveryStatus
+	return &response, a.sendAny(ctx, http.MethodGet, "/v1/cloud_storage/automated_recovery", http.NoBody, &response)
+}
+

--- a/src/go/rpk/pkg/api/admin/api_cloud_storage_test.go
+++ b/src/go/rpk/pkg/api/admin/api_cloud_storage_test.go
@@ -1,0 +1,124 @@
+// Copyright 2023 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package admin
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type (
+	testRequestHandler func(w http.ResponseWriter, r *http.Request)
+	testFn             func(t *testing.T) testRequestHandler
+	requestTestCase    struct {
+		name             string
+		testFn           testFn
+		shouldError      bool
+		expectedErrorMsg string
+		expectedResponse interface{}
+	}
+)
+
+func TestStartAutomatedRecovery(t *testing.T) {
+	successfullStartResponse := RecoveryStartResponse{
+		Code:    200,
+		Message: "Automated recovery started",
+	}
+
+	ctx := context.Background()
+	runTest := func(t *testing.T, test requestTestCase) {
+		baseURL := "http://non-existent-url"
+
+		if test.testFn != nil {
+			server := httptest.NewServer(http.HandlerFunc(test.testFn(t)))
+			defer server.Close()
+			baseURL = server.URL
+		}
+		client, err := NewAdminAPI([]string{baseURL}, BasicCredentials{}, nil)
+		assert.NoError(t, err)
+
+		response, err := client.StartAutomatedRecovery(ctx, ".*")
+
+		if test.shouldError {
+			assert.Error(t, err)
+			// Using assert.Contains instead of assert.Equal as some error messages change depending on the environment.
+			assert.Contains(t, err.Error(), test.expectedErrorMsg)
+			return
+		}
+
+		assert.NoError(t, err)
+		assert.Equal(t, test.expectedResponse, response)
+	}
+
+	tests := []requestTestCase{
+		{
+			name: "should call the correct endpoint",
+			testFn: func(t *testing.T) testRequestHandler {
+				return func(w http.ResponseWriter, r *http.Request) {
+					assert.Equal(t, "/v1/cloud_storage/automated_recovery", r.URL.Path)
+					w.WriteHeader(http.StatusOK)
+					resp, err := json.Marshal(successfullStartResponse)
+					assert.NoError(t, err)
+					w.Write(resp)
+				}
+			},
+			shouldError:      false,
+			expectedResponse: successfullStartResponse,
+		},
+		{
+			name: "should have content-type application-json",
+			testFn: func(t *testing.T) testRequestHandler {
+				return func(w http.ResponseWriter, r *http.Request) {
+					assert.Equal(t, "application/json", r.Header.Get("Content-Type"))
+					w.WriteHeader(http.StatusOK)
+					resp, err := json.Marshal(successfullStartResponse)
+					assert.NoError(t, err)
+					w.Write(resp)
+				}
+			},
+			shouldError:      false,
+			expectedResponse: successfullStartResponse,
+		},
+		{
+			name: "should request recovery of all topics",
+			testFn: func(t *testing.T) testRequestHandler {
+				return func(w http.ResponseWriter, r *http.Request) {
+					body, err := io.ReadAll(r.Body)
+					assert.NoError(t, err)
+
+					var recoveryRequestParams RecoveryRequestParams
+					err = json.Unmarshal(body, &recoveryRequestParams)
+					assert.NoError(t, err)
+
+					assert.Equal(t, ".*", recoveryRequestParams.TopicNamesPattern)
+
+					w.WriteHeader(http.StatusOK)
+					resp, err := json.Marshal(successfullStartResponse)
+					assert.NoError(t, err)
+					w.Write(resp)
+				}
+			},
+			shouldError:      false,
+			expectedResponse: successfullStartResponse,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			runTest(t, test)
+		})
+	}
+}

--- a/src/go/rpk/pkg/cli/cmd/topic/autorestore/autorestore.go
+++ b/src/go/rpk/pkg/cli/cmd/topic/autorestore/autorestore.go
@@ -1,0 +1,29 @@
+// Copyright 2023 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package autorestore
+
+import (
+	"github.com/spf13/afero"
+	"github.com/spf13/cobra"
+)
+
+func NewCommand(fs afero.Fs) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "autorestore",
+		Short: "Interact with the autorestore process",
+		Long:  ``,
+	}
+
+	cmd.AddCommand(
+		newStartCommand(fs),
+	)
+
+	return cmd
+}

--- a/src/go/rpk/pkg/cli/cmd/topic/autorestore/autorestore.go
+++ b/src/go/rpk/pkg/cli/cmd/topic/autorestore/autorestore.go
@@ -23,6 +23,7 @@ func NewCommand(fs afero.Fs) *cobra.Command {
 
 	cmd.AddCommand(
 		newStartCommand(fs),
+		newStatusCommand(fs),
 	)
 
 	return cmd

--- a/src/go/rpk/pkg/cli/cmd/topic/autorestore/start.go
+++ b/src/go/rpk/pkg/cli/cmd/topic/autorestore/start.go
@@ -1,0 +1,62 @@
+// Copyright 2023 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+package autorestore
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/api/admin"
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/config"
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/out"
+	"github.com/spf13/afero"
+	"github.com/spf13/cobra"
+)
+
+func newStartCommand(fs afero.Fs) *cobra.Command {
+	var topicNamePattern string
+
+	cmd := &cobra.Command{
+		Use:   "start",
+		Short: "Start the autorestore process",
+		Long:  ``,
+		Run: func(cmd *cobra.Command, args []string) {
+			p := config.ParamsFromCommand(cmd)
+			cfg, err := p.Load(fs)
+			out.MaybeDie(err, "unable to load config: %v", err)
+
+			client, err := admin.NewClient(fs, cfg)
+			out.MaybeDie(err, "unable to initialize admin client: %v", err)
+
+			_, err = client.StartAutomatedRecovery(cmd.Context(), topicNamePattern)
+			var he *admin.HTTPResponseError
+			if errors.As(err, &he) {
+				if he.Response.StatusCode == 404 {
+					body, bodyErr := he.DecodeGenericErrorBody()
+					if bodyErr == nil {
+						out.Die("Not found: %s", body.Message)
+					}
+				} else if he.Response.StatusCode == 400 {
+					body, bodyErr := he.DecodeGenericErrorBody()
+					if bodyErr == nil {
+						out.Die("Cannot start auto-restore: %s", body.Message)
+					}
+				}
+			}
+
+			out.MaybeDie(err, "error starting auto-restore: %v", err)
+			fmt.Printf("Successfully started auto-restore\n")
+
+		},
+	}
+
+	cmd.Flags().StringVar(&topicNamePattern, "topic-name-pattern", ".*", "A regex pattern to match topic names against. Only topics whose names match this pattern will be restored. If not passed, all topics will be restored.")
+
+	return cmd
+}

--- a/src/go/rpk/pkg/cli/cmd/topic/autorestore/status.go
+++ b/src/go/rpk/pkg/cli/cmd/topic/autorestore/status.go
@@ -1,0 +1,43 @@
+// Copyright 2023 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+package autorestore
+
+import (
+	"fmt"
+
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/api/admin"
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/config"
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/out"
+	"github.com/spf13/afero"
+	"github.com/spf13/cobra"
+)
+
+// TODO: add flag to get detailed info (e.g. topic download counts).
+func newStatusCommand(fs afero.Fs) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "start",
+		Short: "Fetch the status of the autorestore process",
+		Long:  ``,
+		Run: func(cmd *cobra.Command, args []string) {
+			p := config.ParamsFromCommand(cmd)
+			cfg, err := p.Load(fs)
+			out.MaybeDie(err, "unable to load config: %v", err)
+
+			client, err := admin.NewClient(fs, cfg)
+			out.MaybeDie(err, "unable to initialize admin client: %v", err)
+
+			status, err := client.PollAutomatedRecoveryStatus(cmd.Context())
+			out.MaybeDie(err, "unable to fetch auto-restore status: %v", err)
+
+			fmt.Printf("Auto-restore status: %s\n", status.State)
+		},
+	}
+
+	return cmd
+}

--- a/src/go/rpk/pkg/cli/cmd/topic/topic.go
+++ b/src/go/rpk/pkg/cli/cmd/topic/topic.go
@@ -11,6 +11,7 @@ package topic
 
 import (
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/cmd/common"
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/cmd/topic/autorestore"
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
 )
@@ -35,6 +36,7 @@ func NewCommand(fs afero.Fs) *cobra.Command {
 	common.AddKafkaFlags(command, &configFile, &user, &password, &mechanism, &enableTLS, &certFile, &keyFile, &truststoreFile, &brokers)
 
 	command.AddCommand(
+		autorestore.NewCommand(fs),
 		newAddPartitionsCommand(fs),
 		newAlterConfigCommand(fs),
 		newConsumeCommand(fs),


### PR DESCRIPTION
Redpanda v23.1 will introduce automated topic recovery from an archival bucket.
This PR adds the functionality to trigger such auto-restore using `rpk topic autorestore start` and check the status with `rpk autorestore status`.

Additionally there is a wait flag for the start command (`--wait`/`-w`), which will configure the command to poll the admin API until there no longer are any pending replica partitions.

## Backports Required

- [ ] v22.3.x
- [ ] v22.2.x
- [ ] v22.1.x

## Release Notes
  * none